### PR TITLE
Add compatibility UUID for Xcode 7.2 beta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Xcode
+xcuserdata

--- a/PreciseCoverage/Info.plist
+++ b/PreciseCoverage/Info.plist
@@ -26,6 +26,7 @@
 	<array>
 		<string>9AFF134A-08DC-4096-8CEE-62A4BB123046</string>
 		<string>7265231C-39B4-402C-89E1-16167C4CC990</string>
+		<string>9AFF134A-08DC-4096-8CEE-62A4BB123046</string>
 	</array>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>


### PR DESCRIPTION
This is needed for plugin to be work on Xcode 7.2 beta version. I'm not sure this UUID changes with every new beta version though. If so, it'd be more proper to wait for release version.
